### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Using Cobra is easy. First, use `go get` to install the latest version
 of the library. This command will install the `cobra` generator executable
 along with the library and its dependencies:
 
-    go get -u github.com/spf13/cobra
+    go get -u github.com/spf13/cobra/cobra
 
 Next, include Cobra in your application:
 


### PR DESCRIPTION
Fix description to actually install generator as well as latest version of the library.

    go get -u github.com/spf13/cobra

would not install the generator binary, only the library

    go get -u github.com/spf13/cobra/cobra

would do as described.